### PR TITLE
[BR-2329] Experiments and variations must be part of an existing enabled set

### DIFF
--- a/Gibe.AbTest.Tests/AbTestingServiceTests.cs
+++ b/Gibe.AbTest.Tests/AbTestingServiceTests.cs
@@ -13,14 +13,181 @@ namespace Gibe.AbTest.Tests
 			return new AbTestingService(repository);
 		}
 
+
+		[Test]
+		public void GetExperiments_Returns_Experiments()
+		{
+			var experiments = Service(AbTestRepositoryEnabledExperimentsAndVariations()).GetExperiments();
+
+			AssertExperiment(experiments.First(), TestExperiment());
+		}
+
 		[Test]
 		public void GetExperiments_Returns_Empty_Experiment_When_No_Experiments()
 		{
-			var fakeAbTestingService = new FakeAbTestRepository(new List<ExperimentDto>(), new List<VariationDto>());
+			var experiments = Service(AbTestRepositoryNoExperiments()).GetExperiments();
 
-			var experiments = Service(fakeAbTestingService).GetExperiments();
+			AssertExperiment(experiments.First(), EmptyExperiment());
+		}
 
-			var expected = new Experiment(new ExperimentDto
+		[Test]
+		public void GetExperiments_Returns_Empty_Experiment_When_No_Enabled_Experiments()
+		{
+			var experiments = Service(AbTestRepositoryNoEnabledExperiments()).GetExperiments();
+
+			AssertExperiment(experiments.First(), EmptyExperiment());
+		}
+
+		[Test]
+		public void GetExperiments_Returns_Empty_Experiment_When_No_Variations()
+		{
+			var experiments = Service(AbTestRepositoryNoVariations()).GetExperiments();
+
+			AssertExperiment(experiments.First(), EmptyExperiment());
+		}
+
+		[Test]
+		public void GetExperiments_Returns_Empty_Experiment_When_No_Enabled_Variations()
+		{
+			var experiments = Service(AbTestRepositoryNoEnabledVariations()).GetExperiments();
+
+			AssertExperiment(experiments.First(), EmptyExperiment());
+		}
+
+		[Test]
+		public void GetVariation_Returns_Variations()
+		{
+			var variation = Service(AbTestRepositoryEnabledExperimentsAndVariations()).GetVariation("exp1", 1);
+
+			AssertVariation(variation, TestVariation());
+		}
+
+		[Test]
+		public void GetVariation_Returns_Empty_Variation_When_No_Experiments()
+		{
+			var variation = Service(AbTestRepositoryNoExperiments()).GetVariation("exp1", 1);
+
+			AssertVariation(variation, EmptyVariation());
+		}
+
+		[Test]
+		public void GetVariation_Returns_Empty_Variation_When_No_Enabled_Experiments()
+		{
+			var variation = Service(AbTestRepositoryNoEnabledExperiments()).GetVariation("exp1", 1);
+
+			AssertVariation(variation, EmptyVariation());
+		}
+
+		[Test]
+		public void GetVariation_Returns_Empty_Variation_When_No_Variations()
+		{
+			var variation = Service(AbTestRepositoryNoVariations()).GetVariation("exp1", 1);
+
+			AssertVariation(variation, EmptyVariation());
+		}
+
+		[Test]
+		public void GetVariation_Returns_Empty_Variation_When_No_Enabled_Variations()
+		{
+			var variation = Service(AbTestRepositoryNoEnabledVariations()).GetVariation("exp1", 1);
+
+			AssertVariation(variation, EmptyVariation());
+		}
+
+		[Test]
+		public void GetVariation_Returns_Empty_Variation_When_Given_Variation_Is_Not_Enabled_When_There_Is_another_Variation_Which_Is_Enabled()
+		{
+			var variation = Service(AbTestRepositoryOneEnabledAndOneDisabledVariations()).GetVariation("exp1", 1);
+
+			AssertVariation(variation, EmptyVariation());
+		}
+
+		[Test]
+		public void GetVariations_Returns_Variations()
+		{
+			var variations = Service(AbTestRepositoryEnabledExperimentsAndVariations()).GetVariations("exp1");
+
+			AssertVariation(variations.First(), TestVariation());
+			Assert.That(variations.Count(), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void GetVariations_Returns_Empty_Variation_When_No_Experiements()
+		{
+			var variations = Service(AbTestRepositoryNoExperiments()).GetVariations("exp1");
+
+			AssertVariation(variations.First(), EmptyVariation());
+			Assert.That(variations.Count(), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void GetVariations_Returns_Empty_Variation_When_No_Enabled_Experiements()
+		{
+			var variations = Service(AbTestRepositoryNoEnabledExperiments()).GetVariations("exp1");
+
+			AssertVariation(variations.First(), EmptyVariation());
+			Assert.That(variations.Count(), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void GetVariations_Returns_Empty_Variation_When_No_Variations()
+		{
+			var variations = Service(AbTestRepositoryNoVariations()).GetVariations("exp1");
+
+			AssertVariation(variations.First(), EmptyVariation());
+			Assert.That(variations.Count(), Is.EqualTo(1));
+		}
+
+		[Test]
+		public void GetVariations_Returns_Empty_Variation_When_No_Enabled_Variations()
+		{
+			var variations = Service(AbTestRepositoryNoEnabledVariations()).GetVariations("exp1");
+
+			AssertVariation(variations.First(), EmptyVariation());
+			Assert.That(variations.Count(), Is.EqualTo(1));
+		}
+
+		private Experiment TestExperiment()
+		{
+			return new Experiment(TestExperimentDto(), new[] { TestVariation() });
+		}
+
+		private ExperimentDto TestExperimentDto()
+		{
+			return new ExperimentDto
+			{
+				Id = "exp1",
+				Key = "exp1",
+				Description = "test experiment",
+				StartDate = new System.DateTime(2019, 01, 01),
+				EndDate = null,
+				Weight = 1,
+				Enabled = true
+			};
+		}
+
+		private Variation TestVariation()
+		{
+			return new Variation(TestVariationDto());
+		}
+
+		private VariationDto TestVariationDto()
+		{
+			return new VariationDto
+			{
+				Id = 0,
+				ExperimentId = "exp1",
+				VariationNumber = 1,
+				Weight = 1,
+				Enabled = true,
+				Definition = "",
+				DesktopOnly = false
+			};
+		}
+
+		private Experiment EmptyExperiment()
+		{
+			return new Experiment(new ExperimentDto
 			{
 				Id = "",
 				Key = "",
@@ -29,36 +196,26 @@ namespace Gibe.AbTest.Tests
 				EndDate = null,
 				Weight = 1,
 				Enabled = true
-			}, new[] { new Variation(0, 1, 1, true, "", "", false) });
-
-			AssertExperiment(experiments.First(), expected);
+			}, new[] { EmptyVariation() });
 		}
 
-		[Test]
-		public void GetVariation_Returns_Empty_Variation_When_No_Experiments()
+		private Variation EmptyVariation()
 		{
-			var fakeAbTestingService = new FakeAbTestRepository(new List<ExperimentDto>(), new List<VariationDto>());
-
-			var variation = Service(fakeAbTestingService).GetVariation("exp1", 1);
-
-			var expected = new Variation(0, 1, 1, true, "", "", false);
-
-
-			AssertVariation(variation, expected);
+			return new Variation(0, 1, 1, true, "", "", false);
 		}
 
-		[Test]
-		public void GetVariations_Returns_Empty_Variation_When_No_Experiments()
-		{
-			var fakeAbTestingService = new FakeAbTestRepository(new List<ExperimentDto>(), new List<VariationDto>());
+		private FakeAbTestRepository AbTestRepositoryEnabledExperimentsAndVariations() => new FakeAbTestRepository(new List<ExperimentDto> { TestExperimentDto() }, new List<VariationDto> { TestVariationDto() });
 
-			var variations = Service(fakeAbTestingService).GetVariations("exp1");
+		private FakeAbTestRepository AbTestRepositoryNoExperiments() => new FakeAbTestRepository(new List<ExperimentDto>(), new List<VariationDto> { new VariationDto { ExperimentId = "exp1", Enabled = true } });
 
-			var expected = new Variation(0, 1, 1, true, "", "", false);
+		private FakeAbTestRepository AbTestRepositoryNoEnabledExperiments() => new FakeAbTestRepository(new List<ExperimentDto> { new ExperimentDto { Enabled = false } }, new List<VariationDto> { new VariationDto { ExperimentId = "exp1", Enabled = true } });
 
-			AssertVariation(variations.First(), expected);
-			Assert.That(variations.Count(), Is.EqualTo(1));
-		}
+		private FakeAbTestRepository AbTestRepositoryNoVariations() => new FakeAbTestRepository(new List<ExperimentDto> { new ExperimentDto { Enabled = true } }, new List<VariationDto>());
+
+		private FakeAbTestRepository AbTestRepositoryNoEnabledVariations() => new FakeAbTestRepository(new List<ExperimentDto> { new ExperimentDto { Enabled = true } }, new List<VariationDto> { new VariationDto { ExperimentId = "exp1", Enabled = false } });
+
+		private FakeAbTestRepository AbTestRepositoryOneEnabledAndOneDisabledVariations() => new FakeAbTestRepository(new List<ExperimentDto> { new ExperimentDto { Enabled = true } }, new List<VariationDto> { new VariationDto { ExperimentId = "exp1", Enabled = false }, new VariationDto { ExperimentId = "exp2", Enabled = true } });
+
 
 		private void AssertExperiment(Experiment actual, Experiment expected)
 		{
@@ -88,6 +245,5 @@ namespace Gibe.AbTest.Tests
 			Assert.That(actual.ExperimentId, Is.EqualTo(expected.ExperimentId));
 			Assert.That(actual.DesktopOnly, Is.EqualTo(expected.DesktopOnly));
 		}
-
 	}
 }

--- a/Gibe.AbTest.Tests/Gibe.AbTest.Tests.csproj
+++ b/Gibe.AbTest.Tests/Gibe.AbTest.Tests.csproj
@@ -36,12 +36,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Gibe.NPoco, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gibe.NPoco.1.0.159\lib\Gibe.NPoco.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Gibe.NPoco.3.1.1\lib\net45\Gibe.NPoco.dll</HintPath>
     </Reference>
-    <Reference Include="NPoco, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NPoco.2.5.77\lib\net40\NPoco.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NPoco, Version=3.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NPoco.3.9.3\lib\net45\NPoco.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
@@ -49,6 +48,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Gibe.AbTest.Tests/packages.config
+++ b/Gibe.AbTest.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Gibe.NPoco" version="1.0.159" targetFramework="net452" />
-  <package id="NPoco" version="2.5.77" targetFramework="net452" />
+  <package id="Gibe.NPoco" version="3.1.1" targetFramework="net452" />
+  <package id="NPoco" version="3.9.3" targetFramework="net452" />
   <package id="NUnit" version="3.4.1" targetFramework="net452" />
 </packages>

--- a/Gibe.AbTest/AbTest.cs
+++ b/Gibe.AbTest/AbTest.cs
@@ -17,7 +17,7 @@ namespace Gibe.AbTest
 
 		public Variation AssignVariation(string userAgent)
 		{
-			var experiments = _abTestingService.GetExperiments().Where(x => x.Enabled);
+			var experiments = _abTestingService.GetExperiments();
 			var selectedExperiment = RandomlySelectOption(experiments);
 			return RandomlySelectOption(FilterVariations(selectedExperiment.Variations, userAgent));
 		}

--- a/Gibe.AbTest/CachingAbTestingService.cs
+++ b/Gibe.AbTest/CachingAbTestingService.cs
@@ -36,7 +36,7 @@ namespace Gibe.AbTest
 				return _cache.Get<Experiment[]>(CacheKey);
 			}
 			var experiments = _abTestingService.GetExperiments().ToArray();
-			_cache.Add(CacheKey, experiments, TimeSpan.FromMinutes(15));
+			_cache.Add(CacheKey, experiments, TimeSpan.FromMinutes(1));
 			return experiments;
 		}
 	}

--- a/Gibe.AbTest/Gibe.AbTest.csproj
+++ b/Gibe.AbTest/Gibe.AbTest.csproj
@@ -31,24 +31,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Gibe.Caching, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gibe.Caching.1.0.159\lib\Gibe.Caching.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Gibe.Caching.1.0.373\lib\Gibe.Caching.dll</HintPath>
     </Reference>
     <Reference Include="Gibe.NPoco, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Gibe.NPoco.1.0.159\lib\Gibe.NPoco.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Gibe.NPoco.3.1.1\lib\net45\Gibe.NPoco.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NPoco, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NPoco.2.5.77\lib\net40\NPoco.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NPoco, Version=3.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NPoco.3.9.3\lib\net45\NPoco.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Gibe.AbTest/packages.config
+++ b/Gibe.AbTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Gibe.Caching" version="1.0.159" targetFramework="net452" />
-  <package id="Gibe.NPoco" version="1.0.159" targetFramework="net452" />
+  <package id="Gibe.Caching" version="1.0.373" targetFramework="net452" />
+  <package id="Gibe.NPoco" version="3.1.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="NPoco" version="2.5.77" targetFramework="net452" />
+  <package id="NPoco" version="3.9.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
ticket: https://jira.gibedigital.net/browse/BR-2329

When retrieving the GetAssignedVariation for a given (ExperimentKey, VariationNumber) we should only be returning the variation if it exists and is enabled, and if it's experiment exists and is enabled. This requirement led to a bit of a refactor of the AbTestingService as we should only be retrieving experiements or variations which are part of an existing and enabled experiment/ variation set. We've increased the test coverage of AbTestingService for this behaviour.