### PR TITLE
[BR-2924] Stop calling SQL multiple times by enumerating only once.

### DIFF
--- a/Gibe.AbTest/AbTestingService.cs
+++ b/Gibe.AbTest/AbTestingService.cs
@@ -17,7 +17,8 @@ namespace Gibe.AbTest
 			var experiments = _abTestRepository.GetExperiments()
 				.Where(e => e.Enabled)
 				.Select(e => new Experiment(e, GetAvailableVariations(e.Id).ToArray()))
-				.Where(e => e.Variations.Any());
+				.Where(e => e.Variations.Any())
+				.ToArray();
 
 			if (experiments.Any())
 			{
@@ -56,14 +57,11 @@ namespace Gibe.AbTest
 		private IEnumerable<Variation> GetAvailableVariations(string experimentId)
 		{
 			var variations = _abTestRepository.GetVariations(experimentId)
-			.Where(v => v.Enabled);
+				.Where(v => v.Enabled)
+				.Select(v => new Variation(v))
+				.ToArray();
 
-			if (variations.Any())
-			{
-				return variations.Select(v => new Variation(v));
-			}
-
-			return Enumerable.Empty<Variation>();
+			return variations.Any() ? variations : Enumerable.Empty<Variation>();
 		}
 
 		private Experiment EmptyExperiment()


### PR DESCRIPTION
Using MiniProfiler I could see duplicate calls to the same SQL statement.

Calls to `.Any()` within the repo layer before returning results were causing multiple database calls.

Added a couple of `.ToArray()`s and reduced call count from 6 (with 4 duplicate calls) to 2 (with no dupes).